### PR TITLE
Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Make a new storage instance. Options include:
 }
 ```
 
-#### `s3.put(key, value, [callback])`
+#### `s3.put(key, value, [metadata], [callback])`
 
 Write a new value.
 

--- a/fs.js
+++ b/fs.js
@@ -86,18 +86,17 @@ FSStorage.prototype.put = function (key, val, meta, cb) {
   if (!cb) cb = noop
 
   key = normalize(this.dir, key)
-  var left = meta ? 2 : 1
-  function done () {
-    left -= 1
-    if (left === 0) cb(null)
-  }
 
   mkdirp(path.dirname(key), function (err) {
     if (err) return cb(err)
-    fs.writeFile(key, val, done)
-    if (meta) {
-      fs.writeFile(key + '.s3meta', JSON.stringify(meta), done)
-    }
+    fs.writeFile(key, val, function (err) {
+      if (err) return cb(err)
+      if (meta) {
+        fs.writeFile(key + '.s3meta', JSON.stringify(meta), cb)
+      } else {
+        cb(null)
+      }
+    })
   })
 }
 

--- a/fs.js
+++ b/fs.js
@@ -161,7 +161,13 @@ FSStorage.prototype.rename = function (src, dest, cb) {
 
   function ondata (data, next) {
     var key = normalize(self.dir, data.key)
-    rename(key, key.replace(src, dest), next)
+    rename(key, key.replace(src, dest), function (err) {
+      if (err) return next(err)
+      rename(key + '.s3meta', key.replace(src, dest) + '.s3meta', function (err) {
+        if (err && err.code !== 'ENOENT') return next(err)
+        next(null)
+      })
+    })
   }
 
   function rename (a, b, cb) {

--- a/fs.js
+++ b/fs.js
@@ -51,16 +51,10 @@ FSStorage.prototype.createListStream = function (opts) {
       var key = next.replace(self.dir, '').slice(1).replace(/\\/g, '/')
       if (key <= marker) return read(size, cb)
       limit--
-      var data = {
+      cb(null, {
         key: key,
         modified: st.mtime,
         size: st.size
-      }
-      fs.readFile(key + '.s3meta', function (err, meta) {
-        // ENOENT just means no meta
-        if (err && err.code !== 'ENOENT') return cb(err)
-        if (meta) data.meta = JSON.parse(meta)
-        cb(null, data)
       })
     }
   })

--- a/s3.js
+++ b/s3.js
@@ -54,12 +54,7 @@ S3Storage.prototype.createListStream = function (opts) {
 
       for (var i = 0; i < len; i++) {
         var c = contents[i]
-        var next = {
-          key: c.Key,
-          size: c.Size,
-          modified: c.LastModified,
-          meta: c.Meta
-        }
+        var next = {key: c.Key, size: c.Size, modified: c.LastModified}
         limit--
         marker = c.Key
         if (i < len - 1) stream.push(next)

--- a/s3.js
+++ b/s3.js
@@ -54,7 +54,12 @@ S3Storage.prototype.createListStream = function (opts) {
 
       for (var i = 0; i < len; i++) {
         var c = contents[i]
-        var next = {key: c.Key, size: c.Size, modified: c.LastModified}
+        var next = {
+          key: c.Key,
+          size: c.Size,
+          modified: c.LastModified,
+          meta: c.Meta
+        }
         limit--
         marker = c.Key
         if (i < len - 1) stream.push(next)
@@ -181,7 +186,11 @@ S3Storage.prototype.createWriteStream = function (key, opts) {
   }
 }
 
-S3Storage.prototype.put = function (key, buf, cb) {
+S3Storage.prototype.put = function (key, buf, meta, cb) {
+  if (typeof meta === 'function') {
+    cb = meta
+    meta = undefined
+  }
   if (!cb) cb = noop
 
   var self = this
@@ -193,7 +202,8 @@ S3Storage.prototype.put = function (key, buf, cb) {
       Bucket: self.bucket,
       ContentType: type,
       Key: key,
-      Body: buf
+      Body: buf,
+      Metadata: meta
     }, cb)
   })
 }
@@ -209,7 +219,7 @@ S3Storage.prototype.get = function (key, cb) {
       Key: key
     }, function (err, data) {
       if (err) return cb(err)
-      cb(null, data.Body)
+      cb(null, data.Body, data.Metadata)
     })
   })
 }

--- a/test.js
+++ b/test.js
@@ -50,18 +50,21 @@ function run (name, st) {
   })
 
   tape(name + ': put and get metadata', function (t) {
-    st.put('hello', Buffer.from('world'), {
+    st.put('message', Buffer.from('world'), {
       sender: 'goto-bus-stop',
       recipient: 'world'
     }, function (err) {
       t.error(err, 'no error')
-      st.get('hello', function (err, buf, meta) {
+      st.rename('message', 'hello', function (err) {
         t.error(err, 'no error')
-        t.same(meta, {
-          sender: 'goto-bus-stop',
-          recipient: 'world'
+        st.get('hello', function (err, buf, meta) {
+          t.error(err, 'no error')
+          t.same(meta, {
+            sender: 'goto-bus-stop',
+            recipient: 'world'
+          })
+          t.end()
         })
-        t.end()
       })
     })
   })


### PR DESCRIPTION
This PR exposes S3's object metadata feature. You can do `.put(objectName, content, { key: 'value' })` to store a metadata key `key` on the object's metadata. For the FS backend, the metadata is stored as a JSON object in `$OBJECT_NAME.s3meta`.

e; lint fails but i just used the same style as the existing code.